### PR TITLE
bugfix for empy commit lists

### DIFF
--- a/src/Provider/GithubProvider.php
+++ b/src/Provider/GithubProvider.php
@@ -81,8 +81,8 @@ class GithubProvider extends AbstractProvider implements ProviderInterface
         $event->repository = $this->createRepository($data['repository']);
         $event->commits = $this->createCommits($data['commits']);
 
-        if (!$event->commits) {
-            $event->commits[] = $this->createCommit($data['head_commit']); // fix empty commits
+        if (!$event->commits and $data['head_commit']) {
+            $event->commits[] = $this->createCommit($data['head_commit']);
         }
 
         $event->type = Util::getPushType($event->ref);


### PR DESCRIPTION
fixes "Uncaught PHP Exception Symfony\Component\Debug\Exception\ContextErrorException: "Catchable Fatal Error: Argument 1 passed to DavidBadura\GitWebhooks\Provider\GithubProvider::createCommit() must be of the type array, null given, called in /var/www/simpspector/vendor/davidbadura/git-webhooks/src/Provider/GithubProvider.php on line 85 and defined" at /var/www/simpspector/vendor/davidbadura/git-webhooks/src/Provider/GithubProvider.php line 155"